### PR TITLE
Update main.lua

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -64,5 +64,5 @@ rollFrame :SetScript("OnEvent", function(self, event, message)
   local min = tonumber(minStr)
   local max = tonumber(maxStr)
   if current == nil or roller == nil or rolls[roller] ~= nil or min ~= 1 or max < 98 or max > 100 then return; end
-  rolls[roller] = {result=result, max=max}
+  rolls[roller] = {result=tonumber(result), max=max}
 end)


### PR DESCRIPTION
Fixed a bug where the result was a string and not a number so when a roller rolled at '9' it would be higher than a roller who rolled an '89.'